### PR TITLE
Store state with multiline strings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,8 @@ version = "1.0.0"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
-WeakRefStrings = "ea10d353-3f73-51f8-a26c-33c1cb351aa5"
 
 [compat]
 HTTP = "0.9"
 JSON = "0.21"
-WeakRefStrings = "1.4"
 julia = "1.6"

--- a/src/Skans.jl
+++ b/src/Skans.jl
@@ -8,11 +8,9 @@ using JSON:
     json,
     parse as jsonparse
 using TOML:
-    parse as tomlparse,
-    print as tomlprint
-using WeakRefStrings:
-    String31,
-    String255
+    parse as tomlparse
+
+const TRIPLEQUOTE = "\"\"\""
 
 include("webpage.jl")
 include("state.jl")

--- a/src/webpage.jl
+++ b/src/webpage.jl
@@ -2,7 +2,7 @@
     Page
 
 Abstract supertype for web pages and mock web pages.
-All Page subtypes are assumed to define a `url::String255`.
+All Page subtypes are assumed to define a `url::String`.
 """
 abstract type Page end
 
@@ -13,11 +13,11 @@ WebPage to be scanned with `url`.
 The `selector` is a function which can be used to scan only a specific region of the page for changes.
 """
 struct WebPage <: Page
-    url::String255
+    url::String
     selector::Function
 
     function WebPage(url::AbstractString; selector=identity)
-        return new(String255(url), selector)
+        return new(string(url)::String, selector)
     end
 end
 
@@ -27,12 +27,12 @@ end
 Mock web page used for testing.
 """
 struct MockPage <: Page
-    url::String255
+    url::String
     html::String
     selector::Function
 
     function MockPage(url::AbstractString, html::String; selector::Function=identity)
-        return new(String255(url), html, selector)
+        return new(string(url)::String, html, selector)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,24 +1,27 @@
 using Skans
+using Skans:
+    TRIPLEQUOTE
 using Test
 
 notify = false
 
+const PAGES = [
+    Skans.MockPage("url1", "a"),
+    Skans.MockPage("url2", "b")
+]
+
 @testset "skan! updating" begin
-    pages = [
-        Skans.MockPage("url1", "a"),
-        Skans.MockPage("url2", "b")
-    ]
-    scans = Skans.scan.(pages)
+    scans = Skans.scan.(PAGES)
     state = Skans.State(scans)
 
     repo = Skans.MockRepo(state)
 
-    changed = skan!(repo, pages; notify)
+    changed = skan!(repo, PAGES; notify)
     @test isempty(changed)
 
     page = Skans.MockPage("url1", "c")
     pagescan = Skans.scan(page)
-    changed = skan!(repo, [page, pages[2]]; notify)
+    changed = skan!(repo, [page, PAGES[2]]; notify)
     @test length(changed) == 1
     @test first(changed).content == "c"
     state = Skans.retrieve(repo)
@@ -49,16 +52,23 @@ end
 end
 
 @testset "Store and read MockFileRepo" begin
-    pages = [
-        Skans.MockPage("url1", "a"),
-        Skans.MockPage("url2", "b")
-    ]
-
     repo = Skans.MockFileRepo()
-    changed = skan!(repo, pages; notify)
+    changed = skan!(repo, PAGES; notify)
     @test length(changed) == 2
     @test first(changed).content == "a"
 
-    changed = skan!(repo, pages; notify)
+    changed = skan!(repo, PAGES; notify)
     @test isempty(changed)
+end
+
+@testset "Multiline TOML" begin
+    scans = Skans.scan.(PAGES)
+    state = Skans.State(scans)
+    expected = """
+        "url1" = $TRIPLEQUOTE
+        a$TRIPLEQUOTE
+        "url2" = $TRIPLEQUOTE
+        b$TRIPLEQUOTE"""
+    actual = Skans.toml(state.scans)
+    @test expected == actual
 end


### PR DESCRIPTION
This makes it easier to compare versions in `state.toml` via the Git diff.