### PR TITLE
Add preview of changes to the notification

### DIFF
--- a/.github/workflows/Skan.yml
+++ b/.github/workflows/Skan.yml
@@ -17,12 +17,12 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - uses: actions/checkout@v2
+
       - shell: julia --color=yes {0}
         run: |
-          using Pkg
-          branch = "${{ env.GITHUB_REF_NAME }}"
-          url = "https://github.com/rikhuijzer/Skans.jl#$branch"
-          Pkg.add(; url)
+          using Pkg: develop
+          develop(; path=pwd())
 
       - shell: julia --color=yes {0}
         env:

--- a/.github/workflows/Skan.yml
+++ b/.github/workflows/Skan.yml
@@ -18,7 +18,11 @@ jobs:
 
     steps:
       - shell: julia --color=yes {0}
-        run: 'using Pkg; Pkg.add(; url="https://github.com/rikhuijzer/Skans.jl#main")'
+        run: |
+          using Pkg
+          branch = "${{ env.GITHUB_REF_NAME }}"
+          url = "https://github.com/rikhuijzer/Skans.jl#$branch"
+          Pkg.add(; url)
 
       - shell: julia --color=yes {0}
         env:

--- a/src/git.jl
+++ b/src/git.jl
@@ -114,5 +114,18 @@ function cleandiff(dir::AbstractString=pwd())
     filtered = filter(lines) do line
         startswith_one(line, '+') || startswith_one(line, '-')
     end
+    threshold = 22
+    if threshold < length(filtered)
+        filtered = first(filtered, threshold)
+        push!(filtered, "[...]")
+    end
     return join(filtered, sep)
+end
+
+function code_block(s::AbstractString, class::AbstractString)
+    return """
+        ```$class
+        $s
+        ```
+        """
 end

--- a/src/git.jl
+++ b/src/git.jl
@@ -74,3 +74,45 @@ function commit!(repo::Repo)
     end
 end
 
+"""
+    diff(dir::AbstractString=pwd())
+
+Return the output of `git diff` inside `dir`.
+"""
+function diff(dir::AbstractString=pwd())
+    cd(dir) do
+        cmd = `git diff`
+        return read(cmd, String)
+    end
+end
+
+"""
+    startswith_one(s::AbstractString, c::Char)::Bool
+
+Return `true` if and only if `c` is at the first position in `s` and not the second.
+"""
+function startswith_one(s::AbstractString, c::Char)::Bool
+    if length(s) == 0
+        return false
+    elseif length(s) == 1
+        return s[1] == c
+    else
+        return s[1] == c && s[2] != c
+    end
+end
+
+"""
+    cleandiff(dir::AbstractString=pwd())
+
+Return the output of a cleaned up `git diff` inside `dir`.
+This keeps only lines starting with `+` or `-` except `+++` or `---` lines.
+"""
+function cleandiff(dir::AbstractString=pwd())
+    uncleaned = diff(dir)
+    sep = '\n'
+    lines = split(uncleaned, sep)
+    filtered = filter(lines) do line
+        startswith_one(line, '+') || startswith_one(line, '-')
+    end
+    return join(filtered, sep)
+end

--- a/src/notify.jl
+++ b/src/notify.jl
@@ -55,14 +55,19 @@ href(url::String) = "<$url>"
 
 hli(text) = "- $text"
 
-function md(changed::Vector{PageScan})
+function md(repo::GitHubRepo, changed::Vector{PageScan})
     urls = [string(scan.page.url)::String for scan in changed]
     items = hli.(href.(urls))
     text = join(items, '\n')
+    details = code_block(cleandiff(repo.dir), "diff")
     return """
         The following pages changed:
 
         $text
+
+        Details:
+
+        $details
         """
 end
 
@@ -80,7 +85,8 @@ function post_issue_comment!(repo::GitHubRepo, num::Int, changed::Vector{PageSca
     repository = repo.repo
     url = "https://api.github.com/repos/$repository/issues/$num/comments"
     headers = github_headers(repo)
-    dic = Dict(:body => md(changed))
+    text = md(repo, changed)
+    dic = Dict(:body => text)
     js = json(dic)
     return post(url, headers, js)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,12 @@ end
     Skans.pull_or_clone!(repo)
 end
 
+@testset "diff" begin
+    @test Skans.startswith_one("+", '+') == true
+    @test Skans.startswith_one("+-", '+') == true
+    @test Skans.startswith_one("++", '+') == false
+end
+
 @testset "Store and read MockFileRepo" begin
     repo = Skans.MockFileRepo()
     changed = skan!(repo, PAGES; notify)


### PR DESCRIPTION
Closes #14

This adds a diff below the notification which, thanks to GitHub's syntax highlighting for `diff` blocks, has even nice colors:

```diff
- old line
+ new line
```

This doesn't yet show the diff for each entry. That would be better, but I have a hard time finding a Git diff on strings. Otherwise, I have to write things to files first and then diff.